### PR TITLE
[mce-qt] Add support for chargering control state tracking. JB#58812

### DIFF
--- a/examples/qml/properties.qml
+++ b/examples/qml/properties.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Jolla Ltd.
+ * Copyright (c) 2019 - 2022 Jolla Ltd.
  * Copyright (c) 2019 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of BSD license as follows:
@@ -81,6 +81,11 @@ ApplicationWindow {
                 DetailItem {
                     label: "ChargerType"
                     value: mceChargerType.text
+                    onValueChanged: console.log("####", label, value)
+                }
+                DetailItem {
+                    label: "ChargingState"
+                    value: mceChargingState.text
                     onValueChanged: console.log("####", label, value)
                 }
                 DetailItem {
@@ -208,6 +213,20 @@ ApplicationWindow {
         id: mceChargerType
         readonly property string validRepr: root.validRepr(valid)
         readonly property string text: validRepr + typeRepr
+    }
+    MceChargingState {
+        id: mceChargingState
+        readonly property string validRepr: root.validRepr(valid)
+        readonly property string valueRepr: {
+            if (value === MceChargingState.Enabled)
+                return "Enabled"
+            if (value === MceChargingState.Disabled)
+                return "Disabled"
+            if (value === MceChargingState.Unknown)
+                return "Unknown"
+            return "???"
+        }
+        readonly property string text: validRepr + valueRepr
     }
     MceDisplay {
         id: mceDisplay

--- a/lib/dbus/com.nokia.mce.request.xml
+++ b/lib/dbus/com.nokia.mce.request.xml
@@ -4,6 +4,9 @@
   "http://standards.freedesktop.org/dbus/1.0/introspect.dtd">
 <node name="/com/nokia/mce/request">
   <interface name="com.nokia.mce.request">
+    <method name="get_charging_state">
+      <arg direction="out" name="charging_state" type="s"/>
+    </method>
     <method name="get_button_backlight">
       <arg direction="out" name="enabled" type="b"/>
     </method>

--- a/lib/dbus/com.nokia.mce.signal.xml
+++ b/lib/dbus/com.nokia.mce.signal.xml
@@ -4,6 +4,9 @@
   "http://standards.freedesktop.org/dbus/1.0/introspect.dtd">
 <node name="/com/nokia/mce/signal">
   <interface name="com.nokia.mce.signal">
+    <signal name="charging_state_ind">
+      <arg name="charging_state" type="s"/>
+    </signal>
     <signal name="sig_button_backlight_ind">
       <arg name="enabled" type="b"/>
     </signal>

--- a/lib/include/qmcechargingstate.h
+++ b/lib/include/qmcechargingstate.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Jolla Ltd.
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of Jolla Ltd nor the names of its contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef QMCE_CHARGINGSTATE_H_
+#define QMCE_CHARGINGSTATE_H_
+
+#include "qmcetypes.h"
+
+class QMCE_EXPORT QMceChargingState : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool valid READ valid NOTIFY validChanged)
+    Q_PROPERTY(State value READ state NOTIFY stateChanged)
+    Q_ENUMS(State)
+public:
+    enum State {
+        Unknown,
+        Enabled,
+        Disabled
+    };
+    QMceChargingState(QObject* aParent = NULL);
+    bool valid() const;
+    State state() const;
+Q_SIGNALS:
+    void validChanged();
+    void stateChanged();
+private:
+    class Private;
+    Private* iPrivate;
+};
+
+#endif // QMCE_CHARGINGSTATE_H_

--- a/lib/lib.pro
+++ b/lib/lib.pro
@@ -30,6 +30,7 @@ SOURCES += \
     src/qmcecallstate.cpp \
     src/qmcechargertype.cpp \
     src/qmcechargerstate.cpp \
+    src/qmcechargingstate.cpp \
     src/qmcedisplay.cpp \
     src/qmcenameowner.cpp \
     src/qmcepowersavemode.cpp \
@@ -44,6 +45,7 @@ PUBLIC_HEADERS += \
     include/qmcecallstate.h \
     include/qmcechargertype.h \
     include/qmcechargerstate.h \
+    include/qmcechargingstate.h \
     include/qmcedisplay.h \
     include/qmcenameowner.h \
     include/qmcepowersavemode.h \

--- a/lib/src/qmcechargingstate.cpp
+++ b/lib/src/qmcechargingstate.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2022 Jolla Ltd.
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of Jolla Ltd nor the names of its contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "qmcechargingstate.h"
+#include "qmceproxy.h"
+
+#include <mce/mode-names.h>
+
+// ==========================================================================
+// QMceChargingState::Private
+// ==========================================================================
+
+class QMceChargingState::Private : public QObject {
+    Q_OBJECT
+public:
+    Private(QMceChargingState* aParent);
+private:
+    void queryValue();
+    void setValid(bool valid);
+private Q_SLOTS:
+    void onNameOwnerChanged();
+    void onQueryFinished(QDBusPendingCallWatcher* aWatcher);
+    void updateValue(QString state);
+private:
+    QMceChargingState* iParent;
+    QSharedPointer<QMceProxy> iProxy;
+public:
+    bool iValid;
+    QMceChargingState::State iValue;
+};
+
+QMceChargingState::Private::Private(QMceChargingState* aParent) :
+    QObject(aParent),
+    iParent(aParent),
+    iProxy(QMceProxy::instance()),
+    iValid(false),
+    iValue(Unknown)
+{
+    QObject::connect(iProxy->signalProxy(),
+                     &QMceSignalProxy::charging_state_ind,
+                     this,
+                     &QMceChargingState::Private::updateValue);
+    QObject::connect(iProxy.data(),
+                     &QMceProxy::nameOwnerChanged,
+                     this,
+                     &QMceChargingState::Private::onNameOwnerChanged);
+    onNameOwnerChanged();
+}
+
+void QMceChargingState::Private::setValid(bool valid)
+{
+    if (iValid != valid) {
+        iValid = valid;
+        Q_EMIT iParent->validChanged();
+    }
+}
+
+void QMceChargingState::Private::updateValue(QString state)
+{
+    QMceChargingState::State value = Unknown;
+
+    if (state == QStringLiteral(MCE_CHARGING_STATE_ENABLED)) {
+        value = Enabled;
+    } else if (state == QStringLiteral(MCE_CHARGING_STATE_DISABLED)) {
+        value = Disabled;
+    }
+
+    if (iValue != value) {
+        iValue = value;
+        Q_EMIT iParent->stateChanged();
+    }
+    setValid(true);
+}
+
+void QMceChargingState::Private::queryValue()
+{
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(
+        iProxy->requestProxy()->get_charging_state(), this);
+    QObject::connect(watcher,
+                     &QDBusPendingCallWatcher::finished,
+                     this,
+                     &QMceChargingState::Private::onQueryFinished);
+}
+
+void QMceChargingState::Private::onQueryFinished(QDBusPendingCallWatcher* aWatcher)
+{
+    QDBusPendingReply<QString> reply(*aWatcher);
+    if (!reply.isError()) {
+        updateValue(reply.value());
+    }
+    aWatcher->deleteLater();
+}
+
+void QMceChargingState::Private::onNameOwnerChanged()
+{
+    if (iProxy->hasNameOwner()) {
+        queryValue();
+    } else {
+        setValid(false);
+    }
+}
+
+// ==========================================================================
+// QMceChargingState
+// ==========================================================================
+
+QMceChargingState::QMceChargingState(QObject* aParent) :
+    QObject(aParent),
+    iPrivate(new Private(this))
+{
+}
+
+bool QMceChargingState::valid() const
+{
+    return iPrivate->iValid;
+}
+
+QMceChargingState::State QMceChargingState::state() const
+{
+    return iPrivate->iValue;
+}
+
+#include "qmcechargingstate.moc"

--- a/plugin/plugins.qmltypes
+++ b/plugin/plugins.qmltypes
@@ -114,6 +114,23 @@ Module {
         Property { name: "type"; type: "Type"; isReadonly: true }
     }
     Component {
+        name: "QMceChargingState"
+        prototype: "QObject"
+        exports: ["Nemo.Mce/MceChargingState 1.0"]
+        exportMetaObjectRevisions: [0]
+        Enum {
+            name: "State"
+            values: {
+                "Unknown": 0,
+                "Enabled": 1,
+                "Disabled": 2
+            }
+        }
+        Property { name: "valid"; type: "bool"; isReadonly: true }
+        Property { name: "value"; type: "State"; isReadonly: true }
+        Signal { name: "stateChanged" }
+    }
+    Component {
         name: "QMceDisplay"
         prototype: "QObject"
         exports: ["Nemo.Mce/MceDisplay 1.0"]

--- a/plugin/qmcedeclarativeplugin.cpp
+++ b/plugin/qmcedeclarativeplugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Jolla Ltd.
+ * Copyright (c) 2016 - 2022 Jolla Ltd.
  * Copyright (c) 2019 Open Mobile Platform LLC.
  * Contact: Slava Monich <slava.monich@jolla.com>
  *
@@ -42,6 +42,7 @@
 #include "qmcebatterystate.h"
 #include "qmcecablestate.h"
 #include "qmcechargerstate.h"
+#include "qmcechargingstate.h"
 #include "qmcepowersavemode.h"
 #include "qmcecallstate.h"
 #include "qmcechargertype.h"
@@ -67,6 +68,7 @@ void QMceDeclarativePlugin::registerTypes(const char* aUri, int aMajor, int aMin
     qmlRegisterType<QMceBatteryStatus>(aUri, aMajor, aMinor, "MceBatteryStatus");
     qmlRegisterType<QMceBatteryState>(aUri, aMajor, aMinor, "MceBatteryState");
     qmlRegisterType<QMceCableState>(aUri, aMajor, aMinor, "MceCableState");
+    qmlRegisterType<QMceChargingState>(aUri, aMajor, aMinor, "MceChargingState");
     qmlRegisterType<QMceChargerState>(aUri, aMajor, aMinor, "MceChargerState");
     qmlRegisterType<QMcePowerSaveMode>(aUri, aMajor, aMinor, "McePowerSaveMode");
     qmlRegisterType<QMceCallState>(aUri, aMajor, aMinor, "MceCallState");

--- a/rpm/libmce-qt5.spec
+++ b/rpm/libmce-qt5.spec
@@ -12,8 +12,8 @@ Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Quick)
-BuildRequires:  pkgconfig(mce) >= 1.28.0
-Requires:       mce >= 1.104.0
+BuildRequires:  pkgconfig(mce) >= 1.30.0
+Requires:       mce >= 1.110.0
 
 %{!?qtc_qmake5:%define qtc_qmake5 %qmake5}
 %{!?qtc_make:%define qtc_make make}


### PR DESCRIPTION
Required constants are defined in mce-dev >= 1.30.0

The D-Bus methods and signals are available in mce >= 1.110.0

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>